### PR TITLE
bug where commas were being added to password

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -125,10 +125,11 @@ function generatePasswordWithCriteria(length, lowercase, uppercase, numeric, spe
   const specialChars = specialCharacters;
 
   let allChars = "";
-  if (lowercase) allChars += lowercaseChars;
-  if (uppercase) allChars += uppercaseChars;
-  if (numeric) allChars += numericChars;
-  if (special) allChars += specialChars;
+  if (lowercase) allChars += lowercaseChars.join('');
+  if (uppercase) allChars += uppercaseChars.join('');
+  if (numeric) allChars += numericChars.join('');
+  if (special) allChars += specialChars.join('');
+
 
   let password = "";
   for (let i = 0; i < length; i++) {


### PR DESCRIPTION
The bug was created by how I concatenated the character arrays when building ⁠ allChars ⁠. 
Instead of concatenating the arrays directly, I was concatenating the elements of the arrays. 

The fix was to change

```
if (lowercase) allChars += lowercaseChars;
```
to
```
if (lowercase) allChars += lowercaseChars.join('');
```
